### PR TITLE
Use pea symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Some more examples can be found [here](https://github.com/speajus/spea-example/t
 
 ## Features
 
-- Lightweight and only 3 methods, `context.register`, `context.resolve` and `pea`.
+- Lightweight nearly everything is done with `peaKey`, `context.register`, `context.resolve` and `pea`.
 - Proxy-based lazy loading of dependencies 
 - No dependencies
 - Type-safe and fully typed
@@ -67,11 +67,40 @@ const userService = context.resolve(UserService);
 userService.getUsers(); // Outputs: Connected to database
 ```
 
+## PeaKey symbols
+
+You can use symbols to register and retrieve services, please use the `peaKey` symbols,
+as they provide type safety and do not require any additional configuration.
+```ts
+import { pea, context, peaKey } from '@speajus/pea';
+class DatabaseService {
+  connect() {
+    console.log('Connected to database');
+  }
+}
+const dbService = peaKey<DatabaseService>("db-service");
+
+// Register the service
+context.register(dbService, DatabaseService);
+
+// Use the service
+class UserService {
+  constructor(private db = pea(dbService)) {}
+
+  getUsers() {
+    this.db.connect();
+    // ... fetch users
+  }
+}
+
+const userService = context.resolve(UserService);
+```
+
 ## Advanced Usage
 
-### Custom Symbols
+### Custom Registry
 
-You can use symbols to register and retrieve services:
+You can use symbols to register and retrieve services, it is preferrable to use the `peaKey` symbols:
 
 ```typescript
 import { pea, context } from '@speajus/pea';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@speajus/pea",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@speajus/pea",
-      "version": "0.0.7",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@speajus/pea",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@speajus/pea",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speajus/pea",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "license": "MIT",
   "description": "A lightweight Dependency Injection (DI) framework for Node.js, based on proxies.",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speajus/pea",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "description": "A lightweight Dependency Injection (DI) framework for Node.js, based on proxies.",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speajus/pea",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "license": "MIT",
   "description": "A lightweight Dependency Injection (DI) framework for Node.js, based on proxies.",
   "type": "module",

--- a/src/ServiceDescriptor.ts
+++ b/src/ServiceDescriptor.ts
@@ -1,0 +1,114 @@
+import { keyOf } from "./context";
+import { has, isConstructor, isFn } from "./guards";
+import { newProxy, proxyKey } from "./newProxy";
+import { serviceSymbol } from "./symbols";
+import { CKey, Constructor, Fn, PeaKey, RegistryType } from "./types";
+
+type Args<T> = T extends Constructor ? ConstructorParameters<T> : T extends Fn ? Parameters<T> : never;
+type Returns<T> = T extends Constructor ? InstanceType<T> : T extends Fn ? ReturnType<T> : never;
+
+
+export class ServiceDescriptor<TRegistry extends RegistryType, T extends Constructor | Fn> {
+
+    static singleton<T extends Constructor | Fn>(service: T, ...args: Args<T>) {
+        return new ServiceDescriptor(service, service, args);
+    }
+
+    static factory<T extends Constructor | Fn>(service: T, ...args: Args<T>) {
+        return new ServiceDescriptor(service, service, args, false);
+    }
+
+
+    readonly [serviceSymbol]: CKey;
+    dependencies?: Set<CKey>;
+
+    private _instance?: Returns<T>;
+    private _invoked = false;
+    private _cacheable = true;
+    private _service?: T;
+    private _args: Args<T> = [] as any;
+    private _proxy?: Returns<T>;
+
+    constructor(
+        key: PeaKey<TRegistry>,
+        service: T,
+        args: Args<T>,
+        cacheable = true,
+    ) {
+        this[serviceSymbol] = keyOf(key);
+        this.service = service;
+        this.args = args as Args<T>;
+        this.cacheable = cacheable;
+
+    }
+
+    get proxy() {
+        return this._proxy ??= newProxy(this[serviceSymbol], () => this.invoke());
+    }
+
+    set cacheable(_cacheable: boolean) {
+        if (this._cacheable === _cacheable) {
+            return;
+        }
+        this.invalidate();
+        this._cacheable = _cacheable;
+    }
+
+    get cacheable() {
+        return this._cacheable;
+    }
+
+    set service(_service: T) {
+        if (this._service === _service) {
+            return;
+        }
+        this.invalidate();
+        this._service = _service;
+    }
+
+    get service() {
+        return this._service!;
+    }
+
+    get args() {
+        return this._args!;
+    }
+
+    set args(_args: Args<T>) {
+        this.invalidate();
+        _args.forEach(arg => {
+            if (has(arg, proxyKey)) {
+                this.addDependency((arg as any)[proxyKey]);
+            }
+        });
+        this._args = _args;
+    }
+
+    hasDependency(key: CKey) {
+        return this.dependencies?.has(key) ?? false;
+    }
+
+    addDependency(...keys: CKey[]) {
+        if (keys.length) {
+            const set = this.dependencies ??= new Set<CKey>();
+            keys.forEach(v => set.add(v));
+        }
+        return this;
+    }
+
+    invalidate() {
+        this._invoked = false;
+        this._instance = undefined;
+    }
+
+    invoke(): Returns<T> {
+        if (this._invoked && this.cacheable) {
+            return this._instance as Returns<T>;
+        }
+        const resp = isConstructor(this.service) ? new this.service(...this.args) : this.service(...this.args);
+        if (this.cacheable) {
+            return this._instance = resp;
+        }
+        return resp;
+    }
+}

--- a/src/__test__/inject.test.ts
+++ b/src/__test__/inject.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@speajus/pea";
 import { EmailService } from "./sample-services/email";
 import { AuthService, authServiceSymbol } from "./sample-services/auth";
-import { connectionSymbol, DBService } from "./sample-services/db";
+import { connectionPeaKey, DBService } from "./sample-services/db";
 import { createNewContext } from "@speajus/pea";
 
 const aiSymbol = Symbol("a");
@@ -81,7 +81,7 @@ describe("pea test", () => {
 
     it("should in inject the things", async () => {
         ctx.register(authServiceSymbol, AuthService);
-        ctx.register(connectionSymbol, "hello");
+        ctx.register(connectionPeaKey, "hello");
         ctx.register(DBService);
         const result = ctx.resolve(EmailService);
         expect(result).toBeInstanceOf(EmailService);

--- a/src/__test__/sample-services/db.ts
+++ b/src/__test__/sample-services/db.ts
@@ -1,25 +1,19 @@
-import { serviceSymbol } from "@speajus/pea";
+import { peaKey, serviceSymbol } from "@speajus/pea";
 import { pea } from "../../context";
 
-export const dbServiceSymbol = Symbol("db-service-type");
+export const dbServiceSymbol = peaKey<typeof DBService>("db-service-type");
 
-declare module "@speajus/pea" {
-  export interface Registry {
-    [dbServiceSymbol]: typeof DBService;
-    [connectionSymbol]: string;
-  }
-}
 
 export interface IDBService {
   connection(): string;
 }
 
-export const connectionSymbol = Symbol("db-service-connection");
+export const connectionPeaKey = peaKey<string>("connection");
 
 export class DBService implements IDBService {
   public static readonly [serviceSymbol] = dbServiceSymbol;
 
-  constructor(private readonly connectionUrl: string = pea(connectionSymbol)) { }
+  constructor(private readonly connectionUrl: string = pea(connectionPeaKey)) { }
   connection() {
     return this.connectionUrl;
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,82 +1,71 @@
-import { newProxy, proxyKey } from "./newProxy";
-import { Registry } from "./registry";
-import { destroySymbol, removeSymbol, serviceSymbol } from "./symbols";
+import { type Registry } from "./registry";
 import {
     hasA,
-    isConstructor,
     isFn,
-    isObjectish,
-    isPrimitive,
     isSymbol,
     PeaError,
 } from "./guards";
 import type {
     Service,
     Constructor,
-    CtxClass,
-    CtxFn,
     ValueOf,
     Fn,
-    Primitive,
-    PrimitiveType,
-    PrimitiveValue,
     VisitFn,
     PeaKey,
-    Ctx,
     CKey,
     RegistryType,
+    Primitive,
+    PrimitiveType,
 } from "./types";
+import { ServiceDescriptor } from "./ServiceDescriptor";
+import { serviceSymbol } from "./symbols";
 
 export type ContextType = InstanceType<typeof Context>;
 
 class Context<TRegistry extends RegistryType = Registry> {
+
     //this thing is used to keep track of dependencies.
-    #dependencies = new Set<CKey>();
-    #map = new Map<CKey, Ctx<TRegistry, any>>();
+    #map = new Map<CKey, ServiceDescriptor<TRegistry, any>>();
     constructor(private readonly parent?: Context<any>) { }
     pea<T extends Fn>(service: T & Service): ValueOf<TRegistry, T>;
     pea<T extends Fn>(service: T): ValueOf<TRegistry, T>;
     pea<T extends Constructor>(service: T & Service): ValueOf<TRegistry, T>;
     pea<T extends Constructor>(service: T): ValueOf<TRegistry, T>;
-    pea<T extends keyof Registry>(service: T): ValueOf<TRegistry, T>;
+    pea<T extends keyof TRegistry>(service: T): ValueOf<TRegistry, T>;
     pea<T extends PrimitiveType>(service: symbol, type: T): ValueOf<TRegistry, T>;
-    pea<T extends PeaKey<TRegistry>, K = never>(
-        service: T,
-        ...args: any[]
-    ): ValueOf<TRegistry, T, K> {
-        const key = keyOf(service);
-        this.#dependencies.add(key);
-        const ctx = this.has(key)
-            ? this.ctx(key)
-            : this.register(service as any, ...args).ctx(key);
-        return ctx.proxy ??= newProxy(key, () => this.resolve(key as any));
 
+    pea(
+        service: unknown,
+        ...args: unknown[]
+    ): unknown {
+
+        return (this.#map.get(keyOf(service as any)) ?? this.register(service as any, ...args)).proxy;
     }
 
     /**
-     * Starting at a service, apply a function to all dependencies.  This is
-     * useful if you want to destroy all dependencies.   This also could be
-     * used for trigger init methods.  It will only visit each dependency once.
-     *
-     *
-     * ```typescript
-     *   context.visit(EmailService, (v)=>{
-     *     v.destroy?.();
-     *     return removeSymbol;
-     *   });
-     *
-     * ```
-     *
-     * @param service
-     * @param fn
-     */
-    visit(fn: VisitFn<TRegistry, unknown>): void;
+       * Starting at a service, apply a function to all dependencies.  This is
+       * useful if you want to destroy all dependencies.   This also could be
+       * used for trigger init methods.  It will only visit each dependency once.
+       *
+       *
+       * ```typescript
+       *   context.visit(EmailService, (v)=>{
+       *     v.destroy?.();
+       *     return removeSymbol;
+       *   });
+       *
+       * ```
+       *
+       * @param service
+       * @param fn
+       */
+    visit(fn: VisitFn<TRegistry, any>): void;
     visit<T extends PeaKey<TRegistry>>(
         service: T,
         fn: VisitFn<TRegistry, T>,
     ): void;
     visit<T extends PeaKey<TRegistry>>(
-        service: T | VisitFn<TRegistry, unknown>,
+        service: T | VisitFn<TRegistry, any>,
         fn?: VisitFn<TRegistry, T> | undefined,
     ) {
         const key = keyOf(service);
@@ -84,7 +73,7 @@ class Context<TRegistry extends RegistryType = Registry> {
             this._visit(key, fn as any);
         } else if (isFn(service)) {
             for (const key of this.#map.keys()) {
-                this._visit(key, service as any);
+                this._visit(key, service as VisitFn<TRegistry, any>);
             }
         } else {
             throw new PeaError("invalid arguments");
@@ -92,114 +81,73 @@ class Context<TRegistry extends RegistryType = Registry> {
     }
     private _visit(
         service: CKey,
-        fn: (value: unknown, mapKey: PeaKey<TRegistry>) => unknown,
+        fn: VisitFn<TRegistry, any>,
         seen = new Set<CKey>(),
     ) {
         if (seen.size === seen.add(service).size) {
             return;
         }
         const ctx = this.ctx(service);
-        if (ctx.dependencies) {
+        if (ctx.dependencies?.size) {
             for (const dep of ctx.dependencies) {
                 this._visit(dep, fn, seen);
             }
         }
-        const result = fn(ctx.instance, service as any);
-        if (result === destroySymbol) {
-            ctx.instance = undefined;
-            ctx.resolved = false;
-        }
-        if (result === removeSymbol) {
-            this.#map.delete(service);
-        } else {
-            ctx.instance = result;
-        }
+        fn(ctx);
     }
 
-    register<T extends Primitive>(service: symbol, value: T): this;
-    register<T extends Fn>(service: symbol, fn: T, ...args: Parameters<T>): this;
+    register<T extends Primitive>(service: symbol, value: T): ServiceDescriptor<TRegistry, T>;
+    register<T extends Fn>(service: symbol, fn: T, ...args: Parameters<T>): ServiceDescriptor<TRegistry, T>;
     register<T extends Constructor>(
         service: symbol,
         constructor: T,
         ...args: ConstructorParameters<T>
-    ): this;
-    register<T extends keyof TRegistry>(service: T, value: TRegistry[T]): this;
+    ): ServiceDescriptor<TRegistry, T>;
+    register<T extends keyof TRegistry>(service: T, value: TRegistry[T]): ServiceDescriptor<TRegistry, T>;
     register<T extends Constructor>(
         service: T,
         ...args: ConstructorParameters<T>
-    ): this;
-    register<T extends Fn>(service: T, ...args: any[]): this;
-    register(service: PeaKey<TRegistry>, ..._args: any[]): this {
+    ): ServiceDescriptor<TRegistry, T>;
+    register<T extends Fn>(service: T, ...args: any[]): ServiceDescriptor<TRegistry, T>;
+    register<T extends PeaKey<TRegistry>>(service: T, ..._args: any[]): ServiceDescriptor<TRegistry, T> {
         const key = keyOf(service);
-        if (this.has(key)) {
-            this.invalidate(key);
-        }
+
         let serv: Constructor | Fn | unknown = service;
         let args: any[] = _args;
 
         if (isSymbol(service)) {
-            if (_args.length === 0) {
-                throw new PeaError(
-                    `service '${String(service)}' could not be registered.`,
-                );
-            }
+
             serv = _args[0];
             args = _args.slice(1);
         }
-        /**
-         * If a value is registered with proxies, than we need to keep track of them. If
-         * it is instatiated with defaults we use the context#dependencies to resolve them.
-         */
-        const dependencies = _args.reduce((set, arg) => {
-            let depKey: CKey | undefined;
-            if (isObjectish(arg) && (depKey = (arg as any)[proxyKey]) != null) {
-                return (set ?? new Set<CKey>()).add(depKey);
+
+        let inst = this.#map.get(keyOf(service));
+
+        if (inst) {
+            if (serv != null && args?.length) {
+                inst.service = serv;
+                inst.args = args;
             }
-            return set;
-        }, undefined as Set<CKey> | undefined);
-
-        const ctx = isFn(serv)
-            ? isConstructor(serv)
-                ? {
-                    _constructor: serv,
-                    resolved: false,
-                    dependencies,
-                    args,
-                }
-                : {
-                    _factory: serv,
-                    resolved: false,
-                    dependencies,
-                    args,
-                }
-            : isPrimitive(serv)
-                ? {
-                    primitive: true,
-                    instance: serv,
-                    resolved: true,
-                } //should be a plain object
-                : {
-                    primitive: false,
-                    instance: serv,
-                    resolved: true,
-                };
-
-        this.ctx(key, ctx);
-        return this;
+            if (inst.invalid) {
+                this.invalidate(key);
+            }
+            return inst;
+        }
+        this.#map.set(key, (inst = new ServiceDescriptor<TRegistry, any>(service, serv, args, true, isFn(serv))));
+        return inst;
     }
     private has(key: CKey): boolean {
         return this.#map.has(key) ?? this.parent?.has(key) ?? false;
     }
-    private ctx(k: CKey, defaults?: Ctx<TRegistry, any>): Ctx<TRegistry, any> {
+    private ctx(k: CKey, defaults?: ServiceDescriptor<TRegistry, any>): ServiceDescriptor<TRegistry, any> {
         let ret = this.#map.get(k) ?? this.parent?.ctx(k);
         if (!ret) {
-            this.#map.set(k, (ret = defaults ?? { resolved: false }));
-        } else if (defaults != null) {
-            Object.assign(ret, defaults);
+            ret = defaults ?? ServiceDescriptor.value(k as any, k);
+            this.#map.set(k, ret);
         }
         return ret;
     }
-    private invalidate(key: CKey, ctx?: Ctx<TRegistry, any>, seen = new Set<CKey>()) {
+    private invalidate(key: CKey, ctx?: ServiceDescriptor<TRegistry, any>, seen = new Set<CKey>()) {
         if (seen.size === seen.add(key).size) {
             return;
         }
@@ -209,86 +157,31 @@ class Context<TRegistry extends RegistryType = Registry> {
             //I don't  think this should happen, but what do I know.
             return;
         }
-        ctx.resolved = false;
-        ctx.instance = undefined;
+        ctx.invalidate();
 
         for (const [k, v] of this.#map) {
             if (
-                v.dependencies?.has(key) &&
-                (isConstructorCtx(v) || isFactoryCtx(v))
+                v.hasDependency(key)
             ) {
                 this.invalidate(k, v, seen);
             }
         }
     }
-
-    resolve<T extends Primitive>(key: symbol, value: T): T;
-    resolve<T extends Constructor>(
-        key: symbol,
-        service: T,
-        ...args: ConstructorParameters<T>
-    ): ValueOf<TRegistry, T>;
-    resolve<T extends Fn>(
-        key: symbol,
-        service: T,
-        ...args: Parameters<T>
-    ): ValueOf<TRegistry, T>;
-    resolve<T extends Constructor & Service>(
-        service: T,
-        ...args: ConstructorParameters<T>
-    ): ValueOf<TRegistry, T>;
-    resolve<T extends Constructor>(
-        service: T,
-        ...args: ConstructorParameters<T>
-    ): ValueOf<TRegistry, T>;
-    resolve<T extends Fn & Service>(
-        service: T,
-        ...args: Parameters<T>
-    ): ValueOf<TRegistry, T>;
-    resolve<T extends Fn>(
-        service: T,
-        ...args: Parameters<T>
-    ): ValueOf<TRegistry, T>;
-    resolve<T extends keyof TRegistry>(service: T): ValueOf<TRegistry, T>;
-    resolve<T extends (Constructor & Service) | Fn | keyof TRegistry>(
+    resolve<T extends PeaKey<TRegistry>>(
         service: T,
         ..._args: any[]
     ): ValueOf<TRegistry, T> {
-        const key = keyOf(service);
-        if (!this.has(key)) {
-            //Tried to resolve a service that was not registered.
-            if (service == null || (isSymbol(service) && _args.length === 0)) {
-                throw new PeaError(
-                    `service '${String(service)}' not registered, and can not be resolved without a corresponding, value, factory, or class.`,
-                );
-            }
-            return this.register(service as any, ..._args).resolve(service as any);
-        }
-
-        const ctx = this.ctx(key);
-        if (ctx.resolved) {
-            return ctx.instance;
-        }
-
-        if (isFactoryCtx<TRegistry>(ctx)) {
-            ctx.resolved = true;
-            ctx.dependencies = this.#dependencies = new Set(ctx.dependencies);
-            ctx.instance = ctx._factory(...ctx.args);
-            return ctx.instance;
-        }
-        if (isConstructorCtx(ctx)) {
-            ctx.resolved = true;
-            ctx.dependencies = this.#dependencies = new Set(ctx.dependencies);
-            ctx.instance = new ctx._constructor(...ctx.args);
-
-            return ctx.instance;
-        }
-        throw new PeaError(`unknown state for '${String(service)}'`);
+        const descriptor = this.register(service as any, ..._args);
+        return descriptor.invoke();
     }
 
     newContext<TTRegistry extends TRegistry = TRegistry>() {
         return new Context<TTRegistry>(this);
     }
+
+
+
+
 }
 
 export function createNewContext<TRegistry extends RegistryType>() {
@@ -296,47 +189,11 @@ export function createNewContext<TRegistry extends RegistryType>() {
 }
 
 export const context = createNewContext<Registry>();
-export function pea<T extends keyof Registry>(service: T): Registry[T];
-export function pea<T extends Fn, K extends keyof Registry>(
-    fn: T & { [serviceSymbol]: K },
-): Registry[K];
-export function pea<T extends Constructor, K extends keyof Registry>(
-    fn: T & { [serviceSymbol]: K },
-): Registry[K];
 
-export function pea<T extends PrimitiveType>(
-    service: symbol,
-    type: T,
-): PrimitiveValue<T>;
-export function pea<T extends Constructor>(constructor: T): InstanceType<T>;
-export function pea<T extends Fn>(factory: T): ReturnType<T>;
-
-export function pea<T extends Constructor | Fn | keyof Registry>(
-    service: T,
-    ...args: any[]
-): T extends Constructor
-    ? InstanceType<T>
-    : T extends Fn
-    ? ReturnType<T>
-    : T extends keyof Registry
-    ? Registry[T]
-    : never {
-    return context.pea.apply(context, [service, ...args] as any) as any;
-}
+export const pea = context.pea.bind(context);
 
 export function keyOf(key: PeaKey<any> | Service): CKey {
     return hasA(key, serviceSymbol, isSymbol)
         ? (key[serviceSymbol] as any)
         : (key as any);
-}
-
-function isFactoryCtx<TRegistry extends RegistryType>(
-    ctx: Ctx<TRegistry, any>,
-): ctx is CtxFn<TRegistry, any> {
-    return hasA(ctx, "_factory", isFn);
-}
-function isConstructorCtx<TRegistry extends RegistryType>(
-    ctx: Ctx<TRegistry, any>,
-): ctx is CtxClass<TRegistry, any> {
-    return hasA(ctx, "_constructor", isFn);
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -15,6 +15,8 @@ import type {
     CKey,
     RegistryType,
     PeaKeyType,
+    OfA,
+    Rest,
 } from "./types";
 import { ServiceDescriptor } from "./ServiceDescriptor";
 import { serviceSymbol } from "./symbols";
@@ -174,9 +176,7 @@ export function keyOf(key: PeaKey<any> | Service): CKey {
 }
 
 
-type Rest<T extends any[]> = T extends [any, ...infer U] ? U : [];
 
-type OfA<T> = (Constructor<T> | Fn<T> | T);
 //The second argument is usually a factory.  It could also be a value.   This tries to enforce if it is a factory, it should 
 // return the right type.   It is a little broken, because if the first argument is a factory (and key) than the second argument
 // should be treated like an argument.   Which seems asymetrical but is I think correct.

--- a/src/context.ts
+++ b/src/context.ts
@@ -15,7 +15,6 @@ import type {
     Constructor,
     CtxClass,
     CtxFn,
-    CtxValue,
     ValueOf,
     Fn,
     Primitive,
@@ -50,10 +49,8 @@ class Context<TRegistry extends RegistryType = Registry> {
         const ctx = this.has(key)
             ? this.ctx(key)
             : this.register(service as any, ...args).ctx(key);
-        return (
-            ctx.proxy ??
-            (ctx.proxy = newProxy(key, () => this.resolve(service as any)))
-        );
+        return ctx.proxy ??= newProxy(key, () => this.resolve(key as any));
+
     }
 
     /**
@@ -294,12 +291,6 @@ class Context<TRegistry extends RegistryType = Registry> {
     }
 }
 
-function* concat<T>(...it: Iterable<T>[]) {
-    for (const i of it) {
-        yield* i;
-    }
-}
-
 export function createNewContext<TRegistry extends RegistryType>() {
     return new Context<TRegistry>();
 }
@@ -333,7 +324,7 @@ export function pea<T extends Constructor | Fn | keyof Registry>(
     return context.pea.apply(context, [service, ...args] as any) as any;
 }
 
-function keyOf(key: PeaKey<any> | Service): CKey {
+export function keyOf(key: PeaKey<any> | Service): CKey {
     return hasA(key, serviceSymbol, isSymbol)
         ? (key[serviceSymbol] as any)
         : (key as any);

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,3 +1,4 @@
+import { proxyKey } from "./newProxy";
 import { serviceSymbol } from "./symbols";
 import { Constructor, Fn, Primitive, PrimitiveType } from "./types";
 
@@ -59,10 +60,12 @@ export function isPrimitiveType(v: unknown): v is PrimitiveType {
         v === BigInt
     );
 }
+export function isPea(v: unknown): v is { [proxyKey]: symbol } {
+    return hasA(v, proxyKey, isSymbol);
+}
 export class PeaError extends Error {
     constructor(message: string) {
         super(message);
         Object.setPrototypeOf(this, Error);
     }
 }
-

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -65,3 +65,4 @@ export class PeaError extends Error {
         Object.setPrototypeOf(this, Error);
     }
 }
+

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,27 @@
+import { Registry } from "./registry";
+import { pea } from "./context";
+
+type PathOf<T, TPath extends string, TKey extends string & keyof T = keyof T & string> =
+    TPath extends TKey ? T[TPath] :
+    TPath extends
+    (`${infer TFirst extends TKey}.${infer TRest}`
+        | `[${infer TFirst extends TKey}]${infer TRest}`)
+    ?
+    PathOf<T[TFirst], TRest> :
+    never;
+
+const toPath = (path: string) => path.split(/\.|\[(.+?)\]/g).filter(Boolean);
+
+function get<T, TKey extends string>(obj: T, key: TKey): PathOf<T, TKey> {
+    return toPath(key).reduce((acc, part) => (acc as any)?.[part] as any, obj) as any;
+}
+
+export function pathOf<
+    T extends keyof Registry,
+    TPath extends string,
+>(
+    service: T,
+    path: TPath,
+) {
+    return (ctx = pea(service)) => get(ctx, path);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
+export type { RegistryType, VisitFn, } from "./types";
 export * from "./symbols";
 export * from "./context";
 export * from "./registry";
-export { RegistryType } from "./types";
+export * from './helpers';

--- a/src/newProxy.ts
+++ b/src/newProxy.ts
@@ -30,7 +30,10 @@ export function newProxy<T extends Constructor>(
             ? value.bind(prim)
             : value;
       }
-      return (val as any)[prop];
+      return val == null ? val
+        : typeof (val as any)[prop] === "function"
+          ? (val as any)[prop].bind(val)
+          : (val as any)[prop];
     },
     set(_target, prop, value) {
       instance()[prop] = value;

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,7 +1,9 @@
+import { PeaKeyType } from "./types";
+
 export const serviceSymbol = Symbol("service");
 export const destroySymbol = Symbol("destroy");
 export const removeSymbol = Symbol("remove");
 
-export const service = <T>(name: string): symbol & { [serviceSymbol]: T } => {
+export const peaKey = <T>(name: string): PeaKeyType<T> => {
     return Symbol(name) as any;
 }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,3 +1,7 @@
 export const serviceSymbol = Symbol("service");
 export const destroySymbol = Symbol("destroy");
 export const removeSymbol = Symbol("remove");
+
+export const service = <T>(name: string): symbol & { [serviceSymbol]: T } => {
+    return Symbol(name) as any;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { ServiceDescriptor } from "./ServiceDescriptor";
 import { destroySymbol, removeSymbol, serviceSymbol } from "./symbols";
 
 export type Constructor = new (...args: any[]) => any;
@@ -10,10 +11,10 @@ export type ServiceReturn<
 > = T extends Constructor
   ? InstanceType<T>
   : T extends Fn
-    ? ReturnType<T>
-    : T extends keyof TRegistry
-      ? TRegistry[T]
-      : never;
+  ? ReturnType<T>
+  : T extends keyof TRegistry
+  ? TRegistry[T]
+  : never;
 
 //This is just a fake type to make key tracking easier.
 export type CKey = { __brand: "ContextKey" };
@@ -51,8 +52,8 @@ export type PeaKey<TRegistry extends RegistryType> =
 export type Ctx<TRegistry extends RegistryType, T> = T extends Constructor
   ? CtxClass<TRegistry, T>
   : T extends Fn
-    ? CtxFn<TRegistry, T>
-    : CtxValue<TRegistry, T>;
+  ? CtxFn<TRegistry, T>
+  : CtxValue<TRegistry, T>;
 
 export interface Service<T extends symbol = symbol> {
   [serviceSymbol]: T;
@@ -65,41 +66,34 @@ export type ValueOf<
 > = T extends Constructor
   ? InstanceType<T>
   : T extends Fn
-    ? ReturnType<T>
-    : T extends keyof TRegistry
-      ? TRegistry[T]
-      : K extends PrimitiveType
-        ? PrimitiveValue<K>
-        : T;
+  ? ReturnType<T>
+  : T extends keyof TRegistry
+  ? TRegistry[T]
+  : K extends PrimitiveType
+  ? PrimitiveValue<K>
+  : T;
 export type Primitive = string | number | boolean | symbol | bigint;
 export type PrimitiveType = String | Number | Boolean | Symbol | BigInt;
 export type PrimitiveValue<T extends PrimitiveType> = T extends String
   ? string
   : T extends Number
-    ? number
-    : T extends Boolean
-      ? boolean
-      : T extends Symbol
-        ? symbol
-        : T extends BigInt
-          ? bigint
-          : never;
+  ? number
+  : T extends Boolean
+  ? boolean
+  : T extends Symbol
+  ? symbol
+  : T extends BigInt
+  ? bigint
+  : never;
 
-type VisitFnType<K, V> = (
-  value: V,
-  mapKey: K,
-) => unknown | typeof destroySymbol | typeof removeSymbol;
+
 
 export type VisitFn<
   TRegistry extends RegistryType,
-  T,
-> = T extends keyof TRegistry
-  ? VisitFnType<keyof TRegistry, TRegistry[T]>
-  : T extends Constructor
-    ? VisitFnType<Constructor, InstanceType<T>>
-    : T extends Fn
-      ? VisitFnType<Fn, ReturnType<T>>
-      : never;
+  T extends PeaKey<TRegistry>,
+> = (
+  value: ServiceDescriptor<TRegistry, T>,
+) => unknown | typeof destroySymbol | typeof removeSymbol;
 
 export interface RegistryType {
   [key: symbol]: any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,59 +1,21 @@
 import { ServiceDescriptor } from "./ServiceDescriptor";
 import { destroySymbol, removeSymbol, serviceSymbol } from "./symbols";
 
-export type Constructor = new (...args: any[]) => any;
-export type Fn = (...args: any[]) => any;
+export type Constructor<T = any> = new (...args: any[]) => T;
+export type Fn<T = any> = (...args: any[]) => T;
 export type AwaitedReturnType<T extends Fn> = Awaited<ReturnType<T>>;
 
-export type ServiceReturn<
-  TRegistry extends RegistryType,
-  T,
-> = T extends Constructor
-  ? InstanceType<T>
-  : T extends Fn
-  ? ReturnType<T>
-  : T extends keyof TRegistry
-  ? TRegistry[T]
-  : never;
 
 //This is just a fake type to make key tracking easier.
 export type CKey = { __brand: "ContextKey" };
 
-interface CtxBase<TRegistry extends RegistryType, T> {
-  resolved: boolean;
-  primitive?: boolean;
-  proxy?: ValueOf<TRegistry, T>;
-  dependencies?: Set<CKey>;
-}
-
-export interface CtxClass<TRegistry extends RegistryType, T extends Constructor>
-  extends CtxBase<TRegistry, InstanceType<T>> {
-  _constructor: T;
-  instance?: InstanceType<T>;
-  args: ConstructorParameters<T>;
-}
-
-export interface CtxFn<TRegistry extends RegistryType, T extends Fn>
-  extends CtxBase<TRegistry, ReturnType<T>> {
-  _factory: T;
-  args: Parameters<T>;
-  instance?: ReturnType<T>;
-}
-export interface CtxValue<TRegistry extends RegistryType, T>
-  extends CtxBase<TRegistry, T> {
-  instance?: T;
-}
-
 export type PeaKey<TRegistry extends RegistryType> =
+  | PeaKeyType
   | Constructor
   | Fn
   | keyof TRegistry;
 
-export type Ctx<TRegistry extends RegistryType, T> = T extends Constructor
-  ? CtxClass<TRegistry, T>
-  : T extends Fn
-  ? CtxFn<TRegistry, T>
-  : CtxValue<TRegistry, T>;
+
 
 export interface Service<T extends symbol = symbol> {
   [serviceSymbol]: T;
@@ -63,15 +25,16 @@ export type ValueOf<
   TRegistry extends RegistryType,
   T,
   K = unknown,
-> = T extends Constructor
+> =
+  T extends PeaKeyType<infer TValue>
+  ? TValue
+  : T extends Constructor
   ? InstanceType<T>
   : T extends Fn
   ? ReturnType<T>
   : T extends keyof TRegistry
   ? TRegistry[T]
-  : K extends PrimitiveType
-  ? PrimitiveValue<K>
-  : T;
+  : never;
 export type Primitive = string | number | boolean | symbol | bigint;
 export type PrimitiveType = String | Number | Boolean | Symbol | BigInt;
 export type PrimitiveValue<T extends PrimitiveType> = T extends String
@@ -98,3 +61,6 @@ export type VisitFn<
 export interface RegistryType {
   [key: symbol]: any;
 }
+
+
+export type PeaKeyType<T = any> = symbol & { [serviceSymbol]: T };

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,3 +64,6 @@ export interface RegistryType {
 
 
 export type PeaKeyType<T = any> = symbol & { [serviceSymbol]: T };
+export type Rest<T extends any[]> = T extends [any, ...infer U] ? U : [];
+
+export type OfA<T> = (Constructor<T> | Fn<T> | T);


### PR DESCRIPTION
This changes the API to make it more configurable and easier to maintain. In addition the types are improved and have introduced the `peaKey` method.    This is not compatible with previous versions.   