### PR TITLE
Making `pea`'s configurable

### DIFF
--- a/packages/pea/src/configure.ts
+++ b/packages/pea/src/configure.ts
@@ -1,0 +1,27 @@
+import { service } from "./newProxy";
+import { Constructor, Fn, PeaKeyType } from "./types";
+
+export function withOptional<T>(value: T):  T  | undefined {
+  service(value).withOptional(true);  
+  return value;
+}
+export function withArgs<T extends Fn<any> | Constructor<any>> (value:T, ...args:T extends Constructor<any> ? ConstructorParameters<any> : Parameters<any>) {
+    service(value).withArgs(...args);
+    return value;
+}
+export function withValue<T>(value:T, val:T extends Constructor<any> ? InstanceType<T> : T extends Fn<any> ? ReturnType<T> : T):T {
+    service(value).withValue(val);
+    return value;
+}
+export function withCacheable<T>(value:T, cacheable:boolean = true):T {
+    service(value).withCacheable(cacheable);
+    return value;
+}
+export function withTags<T>(value:T, tags:PeaKeyType<any>[]):T {
+    service(value).withTags(...tags);
+    return value;
+}
+export function withService<T>(value:T, factory:Constructor<T> | Fn<T>):T {
+    service(value).withService(factory);
+    return value;
+}

--- a/packages/pea/src/newProxy.ts
+++ b/packages/pea/src/newProxy.ts
@@ -1,8 +1,17 @@
-import { nullableSymbol, PeaError } from "./guards";
+import { has, hasA, nullableSymbol, PeaError } from "./guards";
 import { ServiceDescriptor } from "./ServiceDescriptor";
+import { peaKey } from "./symbols";
 import type { Constructor } from "./types";
 
 export const proxyKey = Symbol("@pea/proxy-key");
+export const serviceKey = peaKey<ServiceDescriptor<any, any>>("@pea/service-key");
+
+export function service(v:unknown){
+  if (hasA(v, serviceKey, (v)=>v instanceof ServiceDescriptor)) {
+    return v[serviceKey];
+  }
+  throw new PeaError(`invalid service`);
+}
 
 export function newProxy<T extends Constructor>(
   key: unknown,
@@ -12,6 +21,9 @@ export function newProxy<T extends Constructor>(
     get(_target, prop) {
       if (prop === proxyKey) {
         return key;
+      }
+      if (prop === serviceKey) {
+        return service;
       }
       const val = service.invoke();
       if (prop === nullableSymbol) {


### PR DESCRIPTION
The idea is you can make `pea` configurable, however it may be a mistake because it would be mucking with the `singleton`,.   It might make sense to make this do different things for the single instance.  perhaps clone, the service descriptor and return it.  